### PR TITLE
build: Initial support for GitHub Actions CI

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Build
       working-directory: ${{env.GITHUB_WORKSPACE}}
       # Build Alias Isolation!
-      run: release.cmd ${{env.BUILD_CONFIGURATION}} ${{env.BUILD_ARCHITECTURE}}
+      run: ./release.cmd ${{env.BUILD_CONFIGURATION}} ${{env.BUILD_ARCHITECTURE}}
       
     - name: Upload Build Artifacts
       uses: actions/upload-artifact@v2.2.3
@@ -30,5 +30,5 @@ jobs:
         # Artifact name
         name: ${{env.BUILD_CONFIGURATION}} ${{env.BUILD_ARCHITECTURE}}
         # Use the release.cmd artifacts path (a folder called "release").
-        path: ./release
+        path: release
         if-no-files-found: error

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -33,8 +33,8 @@ jobs:
 
     - name: Extract the Boost source archive to external/boost
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: 7z.exe x ${{steps.download-boost-source.outputs.file-path}} -osrc\external\boost && mv src\external\boost\boost_1_76_0 src\external\boost
-        && rmdir src\external\boost\boost_1_76_0
+      run: 7z.exe x ${{steps.download-boost-source.outputs.file-path}} -osrc\external\boost && move src\external\boost\boost_1_76_0\* src\external\boost
+        && rmdir /s src\external\boost\boost_1_76_0
 
     - name: Build Alias Isolation
       working-directory: ${{env.GITHUB_WORKSPACE}}

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -8,6 +8,9 @@ env:
   # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
   BUILD_CONFIGURATION: release
   BUILD_ARCHITECTURE: x86
+  BOOST_VERSION: 1.75.0
+  BOOST_SOURCE_DIRECTORY: boost_1_75_0
+  BOOST_SOURCE_LOCATION: src\external\boost
 
 jobs:
   build:
@@ -19,28 +22,35 @@ jobs:
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1
 
-    - name: Download latest supported version of Boost
+    - name: Download Boost ${{env.BOOST_VERSION}}
       uses: carlosperate/download-file-action@v1.0.3
       id: download-boost-source
       with:
         # Boost source 7zip package URL.
-        file-url: https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.7z
+        file-url: https://boostorg.jfrog.io/artifactory/main/release/${{env.BOOST_VERSION}}/source/${{env.BOOST_SOURCE_DIRECTORY}}.7z
         # Temporary directory for the Boost source archive during build.
         location: C:\Temp
 
     - name: Print out Boost source archive location
       run: echo "Downloaded Boost source archive to ${{steps.download-boost-source.outputs.file-path}}"
 
-    - name: Extract the Boost source archive to external/boost
+    - name: Extract the Boost source archive
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: 7z.exe x ${{steps.download-boost-source.outputs.file-path}} -osrc\external\boost && move src\external\boost\boost_1_76_0\* src\external\boost
-        && rmdir /s src\external\boost\boost_1_76_0
+      run: 7z.exe x ${{steps.download-boost-source.outputs.file-path}} -osrc\external\boost
+
+    - name: Move the Boost source files to the location expected by Tundra
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: move src\external\boost\${{env.BOOST_SOURCE_DIRECTORY}}\* src\external\boost
+
+    - name: Remove unneeded Boost source directory
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: rmdir src\external\boost\${{env.BOOST_SOURCE_DIRECTORY}} /s
 
     - name: Build Alias Isolation
       working-directory: ${{env.GITHUB_WORKSPACE}}
       # Build Alias Isolation!
       run: ./release.cmd ${{env.BUILD_CONFIGURATION}} ${{env.BUILD_ARCHITECTURE}}
-      
+
     - name: Upload build artifacts
       uses: actions/upload-artifact@v2.2.3
       with:

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Remove unneeded Boost source directory
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: rmdir src\external\boost\${{env.BOOST_SOURCE_DIRECTORY}} /s
+      run: rmdir src\external\boost\${{env.BOOST_SOURCE_DIRECTORY}}
 
     - name: Build Alias Isolation
       working-directory: ${{env.GITHUB_WORKSPACE}}

--- a/compile.cmd
+++ b/compile.cmd
@@ -87,9 +87,9 @@ if defined %MSBUILD% (
 	echo.
 	echo [Building Alias Isolation...]
 	if "%ARCHITECTURE%" == "x64" (
-		tools\tundra2\bin\tundra2 win64-msvc-%CONFIGURATION%-default
+		tools\tundra2\bin\tundra2.exe win64-msvc-%CONFIGURATION%-default
 	) else (
-		tools\tundra2\bin\tundra2 win32-msvc-%CONFIGURATION%-default
+		tools\tundra2\bin\tundra2.exe win32-msvc-%CONFIGURATION%-default
 	)
 
 	rem If we do not have an errorlevel of 0, then something went wrong during the Tundra build.


### PR DESCRIPTION
Tundra currently doesn't work in GitHub Actions' CI environment, so we might have to move to a system such as CMake.